### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 ####################################
 
-StrRingBuffer               KEYWORD1
+StrRingBuffer	KEYWORD1
 
 ####################################
 # Methods and Functions (KEYWORD2)
 ####################################
 
-reset                       KEYWORD2
-buflen                      KEYWORD2
-strlen                      KEYWORD2
-push                        KEYWORD2
-pop                         KEYWORD2
-peek                        KEYWORD2
-getstr                      KEYWORD2
-getnstr                     KEYWORD2
-pushstr                     KEYWORD2
-pushnstr                    KEYWORD2
-strcmp                      KEYWORD2
-strncmp                     KEYWORD2
-endswith                    KEYWORD2
-endsnwith                   KEYWORD2
+reset	KEYWORD2
+buflen	KEYWORD2
+strlen	KEYWORD2
+push	KEYWORD2
+pop	KEYWORD2
+peek	KEYWORD2
+getstr	KEYWORD2
+getnstr	KEYWORD2
+pushstr	KEYWORD2
+pushnstr	KEYWORD2
+strcmp	KEYWORD2
+strncmp	KEYWORD2
+endswith	KEYWORD2
+endsnwith	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords